### PR TITLE
Feature/parser

### DIFF
--- a/src/parser/ast.c
+++ b/src/parser/ast.c
@@ -52,7 +52,7 @@ static void	command_name(t_list *token_list, t_token **look_ahead,
 	t_token	*token;
 
 	if (!*look_ahead)
-		return;
+		return ;
 	if (is_identifier(*look_ahead) == FALSE)
 	{
 		if (!errno)

--- a/src/parser/ast.c
+++ b/src/parser/ast.c
@@ -6,7 +6,7 @@
 /*   By: dyunta <dyunta@student.42madrid.com>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/07 12:33:21 by dyunta            #+#    #+#             */
-/*   Updated: 2024/11/18 18:37:08 by dyunta           ###   ########.fr       */
+/*   Updated: 2024/11/18 18:54:05 by dyunta           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,21 +51,14 @@ static void	command_name(t_list *token_list, t_token **look_ahead,
 {
 	t_token	*token;
 
-	if (!*look_ahead)
-		return ;
-	if (is_identifier(*look_ahead) == FALSE)
+	if (is_identifier(*look_ahead) == TRUE)
 	{
-		if (!errno)
-			send_error("syntax error near unexpected token: ",
-				(*look_ahead)->value, 1);
-		errno = 42;
-		return ;
+		token = initialize_token();
+		token->type = (*look_ahead)->type;
+		token->value = ft_strdup((*look_ahead)->value);
+		get_next_token(token_list, look_ahead);
+		ft_lstadd_back(&cmd->tokens, ft_lstnew(token));
 	}
-	token = initialize_token();
-	token->type = (*look_ahead)->type;
-	token->value = ft_strdup((*look_ahead)->value);
-	get_next_token(token_list, look_ahead);
-	ft_lstadd_back(&cmd->tokens, ft_lstnew(token));
 }
 
 static void	redirection(t_list *token_list, t_token **look_ahead,

--- a/src/parser/ast.c
+++ b/src/parser/ast.c
@@ -6,7 +6,7 @@
 /*   By: dyunta <dyunta@student.42madrid.com>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/07 12:33:21 by dyunta            #+#    #+#             */
-/*   Updated: 2024/10/23 20:46:03 by dyunta           ###   ########.fr       */
+/*   Updated: 2024/11/18 18:37:08 by dyunta           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,6 +51,8 @@ static void	command_name(t_list *token_list, t_token **look_ahead,
 {
 	t_token	*token;
 
+	if (!*look_ahead)
+		return;
 	if (is_identifier(*look_ahead) == FALSE)
 	{
 		if (!errno)
@@ -75,7 +77,7 @@ static void	redirection(t_list *token_list, t_token **look_ahead,
 	{
 		redir = initialize_redir(*look_ahead);
 		get_next_token(token_list, look_ahead);
-		if ((*look_ahead)->type != WORD)
+		if (!*look_ahead || (*look_ahead)->type != WORD)
 		{
 			if (!errno)
 			{

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -60,6 +60,8 @@ static	t_list	*descent_parser(t_list *token_list)
 	t_list	*cmds;
 	t_token	*look_ahead;
 
+	if (!token_list)
+		return (NULL);
 	look_ahead = (t_token *)token_list->content;
 	cmds = full_command(token_list, &look_ahead);
 	if (errno)

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: dyunta <dyunta@student.42madrid.com>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/07 12:26:03 by dyunta            #+#    #+#             */
-/*   Updated: 2024/10/23 20:53:21 by dyunta           ###   ########.fr       */
+/*   Updated: 2024/11/18 18:43:50 by dyunta           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,11 +27,9 @@ void	parser(t_data *core)
 	core->line = initialize_line();
 	core->line->cmds = descent_parser(
 			execute_expansions(token_list, core->env, core->errcode));
-	// ft_lstiter(token_list, &print_tokens);
 	core->line->pids = ft_calloc(ft_lstsize(core->line->cmds),
 			sizeof(int));
 	ft_lstclear(&token_list, &free_token);
-	// ft_lstiter(core->line->cmds, &print_command);
 }
 
 static t_list	*full_command(t_list *token_list, t_token	**look_ahead)


### PR DESCRIPTION
This pull request includes several changes to the parser implementation and some updates to file headers. The most important changes include modifying conditions in the `command_name` and `redirection` functions, adding a null check in the `descent_parser` function, and updating the subproject commit reference.

### Parser implementation improvements:

* [`src/parser/ast.c`](diffhunk://#diff-db13b9b2bd67ff54c8420503e443e69b1dff1bfcefd0dcf74ea16f2e6394eddaL54-R62): Changed the condition in the `command_name` function to check if `is_identifier(*look_ahead)` is `TRUE` instead of `FALSE`. Removed error handling code that is no longer needed.
* [`src/parser/ast.c`](diffhunk://#diff-db13b9b2bd67ff54c8420503e443e69b1dff1bfcefd0dcf74ea16f2e6394eddaL78-R73): Updated the condition in the `redirection` function to check if `*look_ahead` is null or if its type is not `WORD`.
* [`src/parser/parser.c`](diffhunk://#diff-a07f146eb89913dc369f69ee0108bc864842ce31211a05b121e5c3c432cdb16eR61-R62): Added a null check for `token_list` in the `descent_parser` function to prevent potential null pointer dereferences.

### Code cleanup:

* [`src/parser/parser.c`](diffhunk://#diff-a07f146eb89913dc369f69ee0108bc864842ce31211a05b121e5c3c432cdb16eL30-L34): Removed commented-out debug code in the `parser` function.

### Subproject update:

* [`libft`](diffhunk://#diff-8159fd83ddd91235fc058696c854c507a3a06d4acd45313c5f518a2ac9411778L1-R1): Updated the subproject commit reference to a new commit.