### PR TITLE
Feature/parser

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,13 +6,24 @@
 /*   By: kde-la-c <kde-la-c@student.42madrid>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/22 18:27:29 by kde-la-c          #+#    #+#             */
-/*   Updated: 2024/10/23 20:14:58 by dyunta           ###   ########.fr       */
+/*   Updated: 2024/11/24 12:41:29 by dyunta           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef MINISHELL_H
 # define MINISHELL_H
+
+# ifndef HOSTNAME
+#  define HOSTNAME	"host"
+# endif
+
 # define METACHARACTERS " |<>\t\n"
+
+// TODO: siginterrupt in heredoc, i.e. ctrl-c
+
+# define GRN_BOLD		"\001\033[1;32m\002"
+# define BLU_BOLD		"\001\033[1;34m\002"
+# define RES			"\001\033[0m\002"
 
 # include "../libft/libft.h"
 # include <readline/history.h>
@@ -57,8 +68,6 @@ typedef enum e_token_type
 }	t_token_type;
 
 /* STRUCTS */
-
-
 typedef struct s_fds
 {
 	int	stdfdin;
@@ -133,11 +142,11 @@ typedef struct s_data
 
 /* core */
 
-int				minishell(t_data *core);
-t_var			*get_env(t_data *core, char *key);
-t_var			*split_var(char *var_brut);
-char			**get_env_array(t_list *env);
-int				init_core(t_data *core, char **argv, char **envp);
+int			minishell(t_data *core);
+t_var		*get_env(t_data *core, char *key);
+t_var		*split_var(char *var_brut);
+char		**get_env_array(t_list *env);
+int			init_core(t_data *core, char **argv, char **envp);
 
 /* lexer */
 
@@ -161,63 +170,64 @@ t_command	*command(t_list *token_list, t_token **look_ahead);
 void		get_next_token(t_list *token_list, t_token **look_ahead);
 t_list		*execute_expansions(t_list *token_list, const t_list *env, int err);
 char		*find_var(const t_list *env, char *key, int errcode);
-char		*expand_var_concat(const t_list *env, const char *value, int errcode);
+char		*expand_var_concat(const t_list *env,
+				const char *value, int errcode);
 
 /* exec */
 
-int				executor(t_data *core);
-int				get_redirs(t_command *command, t_fds *fds);
-int				get_infiles(t_list *redirs, t_fds *fds, int iscommand);
-int				get_outfiles(t_list *redirs, t_fds *fds);
-int				isbuiltin(char *cmdpath);
-char			*get_cmdpath(char *cmd, t_var *envpaths);
-char			**get_arg_array(t_command *command);
-int				hasinput(t_list *redirs);
-int				hasoutput(t_list *redirs);
-int				set_fds(t_fds *fds, t_data *core, int cmd_nb);
-int				close_fds(t_fds *fds);
-int				reset_stdfds(t_data *core);
-int				save_stdfds(t_data *core);
-int				init_pipes(t_data *core);
-int				do_heredocs(t_list *commands);
-int				do_fileredir(t_command *command, t_fds fds);
-int				exec_builtin(t_data *core, char *cmdpath, char **args);
-int				do_piperedir(t_data *core, int cmd_nb);
-int				close_parent_pipes(t_data *core, int cmd_nb);
+int			executor(t_data *core);
+int			get_redirs(t_command *command, t_fds *fds);
+int			get_infiles(t_list *redirs, t_fds *fds, int iscommand);
+int			get_outfiles(t_list *redirs, t_fds *fds);
+int			isbuiltin(char *cmdpath);
+char		*get_cmdpath(char *cmd, t_var *envpaths);
+char		**get_arg_array(t_command *command);
+int			hasinput(t_list *redirs);
+int			hasoutput(t_list *redirs);
+int			set_fds(t_fds *fds, t_data *core, int cmd_nb);
+int			close_fds(t_fds *fds);
+int			reset_stdfds(t_data *core);
+int			save_stdfds(t_data *core);
+int			init_pipes(t_data *core);
+int			do_heredocs(t_list *commands);
+int			do_fileredir(t_command *command, t_fds fds);
+int			exec_builtin(t_data *core, char *cmdpath, char **args);
+int			do_piperedir(t_data *core, int cmd_nb);
+int			close_parent_pipes(t_data *core, int cmd_nb);
 
 /* builtins */
 
-int				ft_pwd(t_data *core);
-int				ft_echo(char **args);
-int				ft_cd(t_data *core, char **args);
-int				ft_env(t_data *core);
-int				ft_export(t_data *core, char **args);
-int				export_single(t_data *core, char *arg);
-int				ft_unset(t_data *core, char **args);
-int				unset_single(t_data *core, char *key);
-int				ft_exit(char **args, int ischild);
+int			ft_pwd(t_data *core);
+int			ft_echo(char **args);
+int			ft_cd(t_data *core, char **args);
+int			ft_env(t_data *core);
+int			ft_export(t_data *core, char **args);
+int			export_single(t_data *core, char *arg);
+int			ft_unset(t_data *core, char **args);
+int			unset_single(t_data *core, char *key);
+int			ft_exit(char **args, int ischild);
 
 /* utils */
 
-void			free_struct(t_data *core);
-void			free_line(t_line *line);
-void			free_cmd(void *cont);
-void			free_var(void *cont);
-void			free_token(void *cont);
-void			free_line(t_line *line);
+void		free_struct(t_data *core);
+void		free_line(t_line *line);
+void		free_cmd(void *cont);
+void		free_var(void *cont);
+void		free_token(void *cont);
+void		free_line(t_line *line);
 
 /* errors */
-int send_error(char *err_msg, char *detail_msg, int exit_status);
+int			send_error(char *err_msg, char *detail_msg, int exit_status);
 
 /* printers */
 
-void	print_var_env(void *cont);
-void	print_var_exp(void *cont);
-void	print_str(void *cont);
-void	print_command(void *cont);
-void	print_tokens(void *cont);
-int		hola(char *str);
-void	print_execve(char *cmdpath, char **args, char **envp);
-void	print_fds(t_fds fds);
+void		print_var_env(void *cont);
+void		print_var_exp(void *cont);
+void		print_str(void *cont);
+void		print_command(void *cont);
+void		print_tokens(void *cont);
+int			hola(char *str);
+void		print_execve(char *cmdpath, char **args, char **envp);
+void		print_fds(t_fds fds);
 
 #endif

--- a/src/core/init_core.c
+++ b/src/core/init_core.c
@@ -6,7 +6,7 @@
 /*   By: kde-la-c <kde-la-c@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/21 16:56:20 by kde-la-c          #+#    #+#             */
-/*   Updated: 2024/08/31 19:19:34 by kde-la-c         ###   ########.fr       */
+/*   Updated: 2024/11/21 20:43:17 by dyunta           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,7 +29,7 @@ t_var	*split_var(char *var_brut)
 		return (free(var), NULL);
 	tmpenv = ft_strdup(var_brut);
 	if (!tmpenv)
-		return (free(var), free(var->key), NULL);
+		return (free(var->key), free(var), NULL);
 	if (!ft_strchr(tmpenv, '='))
 	{
 		var->value = ft_strdup("");
@@ -37,7 +37,7 @@ t_var	*split_var(char *var_brut)
 	}
 	var->value = ft_strdup(ft_strchr(tmpenv, '=') + 1);
 	if (!var->value)
-		return (free(tmpenv), free(var), free(var->key), NULL);
+		return (free(tmpenv), free(var->key), free(var), NULL);
 	return (free(tmpenv), var);
 }
 

--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -88,11 +88,9 @@ int	process_single(t_data *core, t_command *command, int cmd_nb)
 int	process_multiple(t_data *core, t_list *commands)
 {
 	int			i;
-	int			status;
 	t_command	*command;
 
 	i = 0;
-	status = 0;
 	while (commands)
 	{
 		command = (t_command *)commands->content;

--- a/src/executor/heredoc.c
+++ b/src/executor/heredoc.c
@@ -35,6 +35,13 @@ char	*get_tmpname(void)
 	return (NULL);
 }
 
+static void	heredoc_end_of_file(const char *line)
+{
+	if (line == NULL)
+		send_error("warning: ",
+			"here-document delimited by end-of-file", EXIT_SUCCESS);
+}
+
 char	*heredoc_loop(char *limiter, char *tmpname)
 {
 	int		fd;
@@ -51,13 +58,14 @@ char	*heredoc_loop(char *limiter, char *tmpname)
 	fd = open(tmpname, O_RDWR | O_CREAT | O_EXCL, 0644);
 	if (fd == -1 || access(tmpname, F_OK) == -1)
 		return (NULL);
-	line = readline(">");
+	line = readline("> ");
 	while (ft_strncmp(line, limiter, ft_strlen(limiter) + 1))
 	{
 		ft_putendl_fd(line, fd);
 		free(line);
-		line = readline(">");
+		line = readline("> ");
 	}
+	heredoc_end_of_file(line);
 	free(line);
 	close(fd);
 	return (tmpname);

--- a/src/parser/ast.c
+++ b/src/parser/ast.c
@@ -6,7 +6,7 @@
 /*   By: dyunta <dyunta@student.42madrid.com>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/07 12:33:21 by dyunta            #+#    #+#             */
-/*   Updated: 2024/11/18 18:54:05 by dyunta           ###   ########.fr       */
+/*   Updated: 2024/11/21 21:05:06 by dyunta           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -101,6 +101,12 @@ t_command	*command(t_list *token_list, t_token **look_ahead)
 	redirection(token_list, look_ahead, cmd);
 	options(token_list, look_ahead, cmd);
 	redirection(token_list, look_ahead, cmd);
+	if (!errno && !cmd->tokens && !cmd->redirs)
+	{
+		errno = 42;
+		send_error("syntax error near unexpected token: ",
+			(*look_ahead)->value, 1);
+	}
 	if (errno)
 		return (free_cmd(cmd), NULL);
 	return (cmd);

--- a/src/parser/lexer.c
+++ b/src/parser/lexer.c
@@ -6,7 +6,7 @@
 /*   By: dyunta <dyunta@student.42madrid.com>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/17 18:12:28 by dyunta            #+#    #+#             */
-/*   Updated: 2024/09/27 00:15:35 by dyunta           ###   ########.fr       */
+/*   Updated: 2024/11/24 11:16:52 by dyunta           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,9 +24,8 @@ t_list	*lexer(void)
 	user_input = loop_readline();
 	if (!user_input || !*user_input)
 	{
-		free(user_input);
 		errno = 42;
-		return (NULL);
+		return (free(user_input), NULL);
 	}
 	token_list = tokenizer(user_input);
 	add_history(user_input);

--- a/src/parser/lexer.c
+++ b/src/parser/lexer.c
@@ -113,5 +113,10 @@ static char	*loop_readline(void)
 		free(tmp_str1);
 		tmp_str1 = ft_strjoin_f12(tmp_str2, readline("> "));
 	}
+	if (tmp_str1 == NULL)
+	{
+		ft_putendl_fd("exit", STDOUT_FILENO);
+		exit(EXIT_SUCCESS);
+	}
 	return (tmp_str1);
 }

--- a/src/parser/prompt.c
+++ b/src/parser/prompt.c
@@ -1,0 +1,3 @@
+//
+// Created by viodid on 11/24/24.
+//

--- a/src/utils/errors.c
+++ b/src/utils/errors.c
@@ -6,7 +6,7 @@
 /*   By: dyunta <dyunta@student.42madrid.com>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/27 21:05:53 by dyunta            #+#    #+#             */
-/*   Updated: 2024/09/07 12:20:21 by dyunta           ###   ########.fr       */
+/*   Updated: 2024/11/24 11:26:45 by dyunta           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,7 @@
 
 int32_t	send_error(char *err_msg, char *detail_msg, int exit_status)
 {
-	ft_putstr_fd("minishell: ", STDERR_FILENO);
+	ft_putstr_fd("ˢʰᵉˡˡ: ", STDERR_FILENO);
 	ft_putstr_fd(err_msg, STDERR_FILENO);
 	ft_putendl_fd(detail_msg, STDERR_FILENO);
 	return (exit_status);


### PR DESCRIPTION
This pull request includes various updates and improvements across multiple files in the project. The most important changes involve adding new macros, improving error handling, and updating submodule references.

### General Improvements:
* [`include/minishell.h`](diffhunk://#diff-471850465338484d65e05947dade7a795e3e068ed9502a098e77c91b5ac1582fL9-R27): Added new macros for hostname and text formatting, and included a TODO comment for future improvements.

### Error Handling:
* [`src/executor/heredoc.c`](diffhunk://#diff-919444b332983030d4891a977a4cc56c83a50b1365574aa88f88aeaea70338c9R38-R44): Added a new function `heredoc_end_of_file` to handle end-of-file warnings in heredoc and integrated it into the `heredoc_loop` function. [[1]](diffhunk://#diff-919444b332983030d4891a977a4cc56c83a50b1365574aa88f88aeaea70338c9R38-R44) [[2]](diffhunk://#diff-919444b332983030d4891a977a4cc56c83a50b1365574aa88f88aeaea70338c9R68)
* [`src/parser/ast.c`](diffhunk://#diff-db13b9b2bd67ff54c8420503e443e69b1dff1bfcefd0dcf74ea16f2e6394eddaR104-R109): Added error handling for unexpected tokens in the `command` function.
* [`src/parser/lexer.c`](diffhunk://#diff-14136e83d653d752e7b1d8807b3040b0fe845c5d3b764ea9036315b0352bb684L27-R28): Improved memory management and error handling in the `lexer` and `loop_readline` functions. [[1]](diffhunk://#diff-14136e83d653d752e7b1d8807b3040b0fe845c5d3b764ea9036315b0352bb684L27-R28) [[2]](diffhunk://#diff-14136e83d653d752e7b1d8807b3040b0fe845c5d3b764ea9036315b0352bb684R116-R120)

### Codebase Maintenance:
* [`libft`](diffhunk://#diff-8159fd83ddd91235fc058696c854c507a3a06d4acd45313c5f518a2ac9411778L1-R1): Updated the submodule reference to a new commit.

### Miscellaneous:
* [`src/utils/errors.c`](diffhunk://#diff-7656c3e18ce39c819ad58f550339fd27fdf14132344a17eda0622eb858a776c7L9-R17): Modified the `send_error` function to change the error message prefix.