### PR TITLE
remove global signum, and frees

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -33,8 +33,6 @@
 # include <sys/wait.h>
 # include <signal.h>
 
-extern volatile sig_atomic_t g_signum;
-
 /*================================== ENUMS ===================================*/
 
 typedef enum e_pipe_fds

--- a/src/parser/lexer.c
+++ b/src/parser/lexer.c
@@ -6,7 +6,7 @@
 /*   By: dyunta <dyunta@student.42madrid.com>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/17 18:12:28 by dyunta            #+#    #+#             */
-/*   Updated: 2024/11/26 18:09:49 by dyunta           ###   ########.fr       */
+/*   Updated: 2024/11/26 21:52:46 by dyunta           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -101,13 +101,16 @@ static t_token_type	enum_token_value(const char *value, int parse_quotes)
 
 static char	*loop_readline(t_data *core)
 {
-	char		*tmp_str1;
-	char		*tmp_str2;
+	char	*tmp_str1;
+	char	*tmp_str2;
+	char	*prompt;
 
 	tmp_str1 = NULL;
 	tmp_str2 = NULL;
 	signal_handler(INTER);
-	tmp_str1 = readline(get_prompt(core->env));
+	prompt = get_prompt(core->env);
+	tmp_str1 = readline(prompt);
+	free(prompt);
 	while (tmp_str1 && tmp_str1[0] && tmp_str1[ft_strlen(tmp_str1) - 1] == '\\')
 	{
 		tmp_str2 = ft_strtrim(tmp_str1, "\\");

--- a/src/signals/signals.c
+++ b/src/signals/signals.c
@@ -12,11 +12,8 @@
 
 #include "../../include/minishell.h"
 
-volatile sig_atomic_t	g_signum;
-
 static void	handle_interactive_signals(int g_signum)
 {
-	g_signum = 130;
 	write(STDOUT_FILENO, "\n", 1);
 	rl_replace_line("", FALSE);
 	rl_on_new_line();
@@ -37,7 +34,6 @@ static void	handle_non_interactive_signals(int g_signum)
 
 void	signal_handler(t_shell_mode mode)
 {
-	g_signum = 0;
 	if (mode == INTER)
 	{
 		signal(SIGINT, handle_interactive_signals);


### PR DESCRIPTION
This pull request includes several changes to the `minishell` project, focusing on signal handling and memory management improvements. The most important changes are summarized below:

### Signal Handling Improvements:

* [`include/minishell.h`](diffhunk://#diff-471850465338484d65e05947dade7a795e3e068ed9502a098e77c91b5ac1582fL36-L37): Removed the declaration of the global variable `g_signum`.
* [`src/signals/signals.c`](diffhunk://#diff-33edaa8ae4521b6bd37016b7dca7dbf8f50d4677241c9125a04143372a4ad86cL15-L19): Removed the definition and initialization of the global variable `g_signum`. Updated the `handle_interactive_signals` and `handle_non_interactive_signals` functions to eliminate the use of `g_signum`. [[1]](diffhunk://#diff-33edaa8ae4521b6bd37016b7dca7dbf8f50d4677241c9125a04143372a4ad86cL15-L19) [[2]](diffhunk://#diff-33edaa8ae4521b6bd37016b7dca7dbf8f50d4677241c9125a04143372a4ad86cL40)

### Memory Management Improvements:

* [`src/parser/lexer.c`](diffhunk://#diff-14136e83d653d752e7b1d8807b3040b0fe845c5d3b764ea9036315b0352bb684R106-R113): Modified the `loop_readline` function to store the prompt in a temporary variable and free it after use, preventing potential memory leaks.

### Minor Changes:

* [`src/parser/lexer.c`](diffhunk://#diff-14136e83d653d752e7b1d8807b3040b0fe845c5d3b764ea9036315b0352bb684L9-R9): Updated the file header comment to reflect the new modification date.